### PR TITLE
Connect homepage to remote deals API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,63 @@
+# SpotMijnVlucht Deals
+
+Next.js applicatie voor het tonen van vliegaanbiedingen van SpotMijnVlucht. De app gebruikt een eigen API
+(endpoints gehost op Google Cloud Run) voor het ophalen en beheren van deals en bevat componenten voor een
+in-house admin dashboard.
+
+## Projectstructuur
+
+- `app/` – App Router met de publieke homepage (`page.tsx`) en API-routes (bijv. `api/deals`).
+- `components/` – UI-componenten voor zowel frontend (cards, testimonials) als admin-modules.
+- `lib/` – Helperfuncties en integraties (affiliate tracking, Supabase, normalisatie van deals).
+- `styles/` – Tailwind CSS configuratie en globale stijlen.
+
+## Vereiste omgevingvariabelen
+
+De homepage haalt deals op via `/api/deals`. Deze route proxy’t naar de externe API.
+Stel de volgende variabelen in (bijvoorbeeld via `.env.local` of Vercel Environment Variables):
+
+```env
+# Basis URL van de externe deals-API
+DEALS_API_BASE_URL=https://spotmijnvlucht-api-778985017095.europe-west1.run.app
+
+# Optioneel: pad of volledig endpoint voor het ophalen van deals
+DEALS_API_PATH=/deals
+
+# Optioneel: authenticatie richting de externe API
+DEALS_API_KEY=\<API sleutel>
+DEALS_API_AUTH_HEADER=Authorization
+# Gebruik bij bearer-tokens de spatie aan het einde: "Bearer "
+DEALS_API_KEY_PREFIX="Bearer "
+```
+
+Laat `DEALS_API_KEY`, `DEALS_API_AUTH_HEADER` of `DEALS_API_KEY_PREFIX` leeg als de externe API geen
+authenticatie vereist of een andere header gebruikt.
+
+## Ontwikkelomgeving
+
+```bash
+npm install
+npm run dev
+```
+
+De applicatie draait standaard op `http://localhost:3000`.
+
+### Linting
+
+```bash
+npm run lint
+```
+
+## Deal normalisatie
+
+De normalisatielogica bevindt zich in `lib/deals.ts`. `app/api/deals/route.ts` haalt de externe API op en
+converteert het antwoord naar een uniform formaat. Wanneer de externe API geen data terugstuurt, wordt een
+fallback-deal geleverd zodat de frontend bruikbaar blijft.
+
+## Admin dashboard
+
+De map `components/admin` bevat een uitgebreide set van UI-componenten voor dealbeheer, expiratiebeheer,
+nieuwsbriefinschrijvers en analytics. De bijbehorende API-routes (`/api/admin/*`) dienen nog gekoppeld te
+worden aan een backend of database (bijv. Supabase of de Cloud Run API) zodat data vanuit het dashboard
+kan worden beheerd.
 

--- a/app/api/deals/route.ts
+++ b/app/api/deals/route.ts
@@ -1,73 +1,99 @@
-// app/api/deals/route.ts
-import { NextResponse } from "next/server";
-export const dynamic = "force-dynamic";
+import type { NextRequest } from "next/server"
+import { NextResponse } from "next/server"
 
-export async function GET(req: Request) {
-  const { searchParams } = new URL(req.url);
-  const from = searchParams.get("from") || "AMS";
-  const to = searchParams.get("to") || "IST";
-  // ... diğer parametreler ...
+import {
+  DEFAULT_DEALS_API_BASE_URL,
+  FALLBACK_DEAL,
+  normalizeDealsFromPayload,
+} from "@/lib/deals"
 
-  const token = process.env.TRAVELPAYOUTS_API_TOKEN;
-  
-  // ---- YENİ KONTROL 1: Token'ın gelip gelmediğini kontrol edelim ----
-  console.log("1. API Token Kontrolü:", token ? `Token'ın ilk 5 hanesi: ${token.substring(0, 5)}...` : "Token BULUNAMADI!");
+export const dynamic = "force-dynamic"
 
-  if (!token) {
-    return NextResponse.json({ error: "API token missing" }, { status: 500 });
+const DEFAULT_REMOTE_PATH = "/deals"
+
+const apiBaseUrl = (process.env.DEALS_API_BASE_URL || DEFAULT_DEALS_API_BASE_URL).replace(/\/$/, "")
+const apiPath = process.env.DEALS_API_PATH || DEFAULT_REMOTE_PATH
+const apiKey = process.env.DEALS_API_KEY || process.env.DEALS_API_TOKEN
+const apiAuthHeader = process.env.DEALS_API_AUTH_HEADER || "Authorization"
+const apiKeyPrefix = process.env.DEALS_API_KEY_PREFIX ?? "Bearer "
+
+function buildRemoteUrl(requestUrl: URL): string {
+  const remoteBase = apiPath.startsWith("http")
+    ? apiPath
+    : `${apiBaseUrl}${apiPath.startsWith("/") ? apiPath : `/${apiPath}`}`
+
+  const remoteUrl = new URL(remoteBase)
+
+  requestUrl.searchParams.forEach((value, key) => {
+    if (value !== null && value !== undefined) {
+      remoteUrl.searchParams.set(key, value)
+    }
+  })
+
+  return remoteUrl.toString()
+}
+
+function buildHeaders() {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
   }
 
-  try {
-    const url = new URL("https://api.travelpayouts.com/aviasales/v3/prices_for_dates");
-    url.searchParams.set("origin", from);
-    url.searchParams.set("destination", to);
-    url.searchParams.set("currency", "EUR");
-    url.searchParams.set("limit", "30");
-
-    // ---- YENİ KONTROL 2: Travelpayouts'a hangi URL ile istek attığımızı görelim ----
-    console.log("2. Travelpayouts'a gönderilen URL:", url.toString());
-
-    const res = await fetch(url.toString(), {
-      headers: { "X-Access-Token": token },
-      cache: "no-store",
-    });
-
-    // ---- YENİ KONTROL 3: Travelpayouts'tan gelen yanıtın durumunu görelim ----
-    console.log(`3. Travelpayouts Yanıt Durumu: ${res.status} ${res.statusText}`);
-
-    if (!res.ok) {
-        // Hata durumunda API'den gelen cevabı da loglayalım
-        const errorBody = await res.text();
-        console.error("Travelpayouts API Hata Detayı:", errorBody);
-        throw new Error(`Upstream error ${res.status}`);
+  if (apiKey) {
+    if (apiAuthHeader.toLowerCase() === "authorization") {
+      headers[apiAuthHeader] = `${apiKeyPrefix}${apiKey}`.trim()
+    } else {
+      headers[apiAuthHeader] = apiKey
     }
-    
-    const raw = await res.json();
+  }
 
-    // ---- YENİ KONTROL 4: Travelpayouts'tan gelen HAM VERİYİ görelim ----
-    // Gelen verinin yapısını anlamak için bu en önemli adımdır.
-    console.log("4. Travelpayouts'tan Gelen Ham Veri:", JSON.stringify(raw, null, 2));
+  return headers
+}
 
-    // normalize -> UI ile birebir alan isimleri
-    const items = (raw?.data || []).map((d: any, i: number) => ({
-      id: d.id ?? `${d.origin}-${d.destination}-${i}`,
-      origin: d.origin ?? from,
-      destination: d.destination ?? to,
-      airline: d.airline || d.gate || "",
-      price: d.price || d.value || 0,
-      depart_at: d.departure_at || d.depart_date || "",
-      return_at: d.return_at || d.return_date || "",
-      transfers: d.transfers ?? d.number_of_changes ?? 0,
-      link: d.link || d.deep_link || "",
-    }));
+export async function GET(req: NextRequest) {
+  const requestUrl = new URL(req.url)
+  const remoteUrl = buildRemoteUrl(requestUrl)
 
-    // ---- YENİ KONTROL 5: İşledikten sonraki veriyi görelim ----
-    console.log(`5. İşlenmiş ve Ön Yüze Gönderilmeye Hazır ${items.length} adet Fırsat Bulundu.`);
+  try {
+    const response = await fetch(remoteUrl, {
+      method: "GET",
+      headers: buildHeaders(),
+      cache: "no-store",
+    })
 
-    return NextResponse.json({ items });
-  } catch (e: any) {
-    // ---- YENİ KONTROL 6: Herhangi bir HATA olursa yakalayalım ----
-    console.error("6. CATCH BLOK HATASI:", e.message);
-    return NextResponse.json({ error: e.message }, { status: 500 });
+    const text = await response.text()
+    let payload: unknown
+
+    if (text) {
+      try {
+        payload = JSON.parse(text)
+      } catch (error) {
+        console.error("Deals API returned non-JSON payload", error)
+        payload = null
+      }
+    }
+
+    if (!response.ok) {
+      const message =
+        typeof payload === "object" && payload !== null && "error" in payload
+          ? String((payload as Record<string, unknown>).error)
+          : typeof payload === "object" && payload !== null && "message" in payload
+            ? String((payload as Record<string, unknown>).message)
+            : text || `Remote API error (${response.status})`
+
+      console.error("Deals API error:", response.status, message)
+      return NextResponse.json({ error: message }, { status: response.status })
+    }
+
+    const items = normalizeDealsFromPayload(payload)
+
+    if (items.length === 0) {
+      console.warn("Deals API returned no usable items. Falling back to default deal.")
+    }
+
+    return NextResponse.json({ items: items.length > 0 ? items : [FALLBACK_DEAL] })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "Onbekende fout bij het ophalen van deals."
+    console.error("Failed to load deals:", message)
+    return NextResponse.json({ error: message }, { status: 500 })
   }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,103 +1,177 @@
 // app/page.tsx
-'use client';
+"use client"
 
-import SearchFilterSection from '@/components/search-filter-section';
-import TestimonialsSection from '@/components/testimonials-section';
-import NewsletterSection from '@/components/newsletter-section';
-import EnhancedDealCard from '@/components/enhanced-deal-card';
-import PartnerBrandingFooter from '@/components/partner-branding-footer';
-import DealOfTheDaySection from '@/components/deal-of-the-day-section';
+import { useEffect, useMemo, useState } from "react"
 
-interface FlightDeal {
-  id: string;
-  origin: string;
-  destination: string;
-  airline: string;
-  price: number;
-  depart_at: string;
-  return_at: string;
-  link: string;
-  image?: { src: string; alt: string; };
-  city_name?: string;
-  country_name?: string;
-  duration_days?: number;
-  discount_percentage?: number;
-  rating?: number;
-  review_count?: number;
+import Footer from "@/components/footer"
+import Header from "@/components/header"
+import EnhancedDealCard from "@/components/enhanced-deal-card"
+import PartnerBrandingFooter from "@/components/partner-branding-footer"
+import DealOfTheDaySection from "@/components/deal-of-the-day-section"
+import NewsletterSection from "@/components/newsletter-section"
+import SearchFilterSection from "@/components/search-filter-section"
+import TestimonialsSection from "@/components/testimonials-section"
+import type { AffiliatePartnerKey, NormalizedDeal } from "@/lib/deals"
+import { FALLBACK_DEAL } from "@/lib/deals"
+
+interface DealCardData {
+  id: number
+  origin?: string
+  destination: string
+  country: string
+  originalPrice: number
+  currentPrice: number
+  discount: number
+  airline: string
+  seatsRemaining: number
+  image: string
+  airlineLogo: string
+  expiresAt: Date
+  partner?: AffiliatePartnerKey
+  rating?: number
+  reviewCount?: number
+  competitorPrice?: number
+  bookingsToday?: number
+  link?: string
+  isFeatured?: boolean
+  isDealOfDay?: boolean
 }
 
-const featuredDeal = {
-  id: 1,
-  destination: 'Barcelona',
-  country: 'Spanje',
-  originalPrice: 299,
-  currentPrice: 199,
-  discount: 33,
-  airline: 'KLM',
-  seatsRemaining: 5,
-  image: '/barcelona-sagrada-familia-park-guell.png',
-  airlineLogo: '/klm-logo.png',
-  expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000),
-};
+function parseDate(value?: string) {
+  if (!value) {
+    return new Date(Date.now() + 36 * 60 * 60 * 1000)
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return new Date(Date.now() + 36 * 60 * 60 * 1000)
+  }
+
+  return date
+}
+
+function mapDealToCardData(deal: NormalizedDeal): DealCardData {
+  const expiresAt = parseDate(deal.dealExpiresAt)
+  const currentPrice = deal.currentPrice > 0 ? deal.currentPrice : deal.originalPrice
+  const originalPrice = deal.originalPrice > currentPrice ? deal.originalPrice : currentPrice
+  const discount =
+    deal.discountPercentage > 0
+      ? Math.round(deal.discountPercentage)
+      : originalPrice > 0
+        ? Math.max(Math.round(((originalPrice - currentPrice) / originalPrice) * 100), 0)
+        : 0
+
+  return {
+    id: deal.id,
+    origin: deal.origin,
+    destination: deal.destination,
+    country: deal.country,
+    originalPrice,
+    currentPrice,
+    discount,
+    airline: deal.airline,
+    seatsRemaining: deal.seatsRemaining > 0 ? deal.seatsRemaining : 6,
+    image: deal.imageUrl || "/placeholder.svg",
+    airlineLogo: deal.airlineLogoUrl || "/placeholder.svg",
+    expiresAt,
+    partner: deal.partner,
+    rating: deal.rating,
+    reviewCount: deal.reviewCount,
+    competitorPrice: deal.competitorPrice,
+    bookingsToday: deal.dailyBookings,
+    link: deal.link,
+    isFeatured: deal.isFeatured,
+    isDealOfDay: deal.isDealOfDay,
+  }
+}
+
+const FALLBACK_CARD = mapDealToCardData(FALLBACK_DEAL)
 
 export default function HomePage() {
-  const [deals, setDeals] = useState<FlightDeal[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [deals, setDeals] = useState<DealCardData[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
 
   useEffect(() => {
+    let isMounted = true
+
     async function fetchDeals() {
       try {
-        setIsLoading(true);
-        setError(null);
-        const response = await fetch('/api/deals');
+        setIsLoading(true)
+        setError(null)
+
+        const response = await fetch("/api/deals", {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        })
 
         if (!response.ok) {
-          throw new Error('Deals konden niet worden geladen.');
+          throw new Error(`Deals konden niet worden geladen (status ${response.status}).`)
         }
 
-        const data = await response.json();
-        
-        if (data.error) {
-            throw new Error(data.error);
+        const payload = await response.json()
+        const normalized: NormalizedDeal[] = Array.isArray(payload) ? payload : payload.items ?? []
+
+        const mappedDeals = normalized
+          .map(mapDealToCardData)
+          .filter((deal): deal is DealCardData => Boolean(deal))
+
+        if (!isMounted) {
+          return
         }
 
-        const enrichedDeals = (data.items || []).map((deal: FlightDeal) => ({
-            ...deal,
-            image: {
-                src: `https://source.unsplash.com/400x300/?${deal.destination},city`,
-                alt: `Uitzicht op ${deal.destination}`
-            }
-        }));
-
-        setDeals(enrichedDeals);
-      } catch (err: any) {
-        setError(err.message);
+        setDeals(mappedDeals)
+      } catch (err) {
+        console.error("Failed to fetch deals:", err)
+        if (!isMounted) {
+          return
+        }
+        const message = err instanceof Error ? err.message : "Onbekende fout bij het ophalen van deals."
+        setError(message)
       } finally {
-        setIsLoading(false);
+        if (isMounted) {
+          setIsLoading(false)
+        }
       }
     }
 
-    fetchDeals();
-  }, []);
+    fetchDeals()
+
+    return () => {
+      isMounted = false
+    }
+  }, [])
+
+  const heroDeal = useMemo(() => {
+    if (deals.length === 0) {
+      return FALLBACK_CARD
+    }
+
+    return deals.find((deal) => deal.isDealOfDay) ?? deals.find((deal) => deal.isFeatured) ?? deals[0]
+  }, [deals])
+
+  const visibleDeals = deals.length > 0 ? deals : [FALLBACK_CARD]
 
   return (
-    <div className="bg-gray-50">
+    <div className="bg-gray-50 min-h-screen">
       <Header />
       <main>
         <SearchFilterSection />
-        <DealOfTheDaySection />
-        <DealOfTheDaySection deal={featuredDeal} />
+        {heroDeal && <DealOfTheDaySection deal={heroDeal} />}
         <section className="container mx-auto px-4 md:px-8 py-12">
           <h2 className="text-3xl font-bold text-center mb-8 text-gray-800">Populaire Vliegdeals</h2>
           {isLoading && <p className="text-center py-10">Deals worden geladen...</p>}
-          {error && <p className="text-center text-red-500 py-10">Fout: {error}</p>}
-          {!isLoading && !error && (
+          {error && (
+            <p className="text-center text-red-500 py-6">
+              {error}
+              <br />
+              We tonen een voorbeelddeal zolang er geen live data beschikbaar is.
+            </p>
+          )}
+          {!isLoading && (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-              {deals.length > 0 ? (
-                deals.map((deal) => (
-                  <EnhancedDealCard key={deal.id} deal={deal} />
-                ))
+              {visibleDeals.length > 0 ? (
+                visibleDeals.map((deal) => <EnhancedDealCard key={`${deal.id}-${deal.destination}`} deal={deal} />)
               ) : (
                 <p className="col-span-full text-center py-10">Geen passende deals gevonden.</p>
               )}
@@ -110,5 +184,5 @@ export default function HomePage() {
       </main>
       <Footer />
     </div>
-  );
+  )
 }

--- a/lib/deals.ts
+++ b/lib/deals.ts
@@ -1,0 +1,276 @@
+import { AFFILIATE_PARTNERS } from "@/lib/affiliate-tracking"
+
+export const DEFAULT_DEALS_API_BASE_URL =
+  "https://spotmijnvlucht-api-778985017095.europe-west1.run.app"
+
+export type AffiliatePartnerKey = keyof typeof AFFILIATE_PARTNERS
+
+export interface NormalizedDeal {
+  id: number
+  externalId?: string
+  origin: string
+  destination: string
+  country: string
+  currentPrice: number
+  originalPrice: number
+  discountPercentage: number
+  airline: string
+  airlineLogoUrl: string
+  imageUrl: string
+  departureDate?: string
+  returnDate?: string
+  seatsRemaining: number
+  dealExpiresAt: string
+  rating?: number
+  reviewCount?: number
+  competitorPrice?: number
+  dailyBookings?: number
+  partner: AffiliatePartnerKey
+  link?: string
+  isFeatured: boolean
+  isDealOfDay: boolean
+}
+
+function parseString(value: unknown, fallback = ""): string {
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : fallback
+  }
+
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value.toString() : fallback
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "true" : "false"
+  }
+
+  return fallback
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : fallback
+  }
+
+  if (typeof value === "string") {
+    const sanitized = value.replace(/[^0-9.,-]/g, "").replace(",", ".")
+    const parsed = Number.parseFloat(sanitized)
+    return Number.isFinite(parsed) ? parsed : fallback
+  }
+
+  return fallback
+}
+
+function parseDateToIso(value: unknown): string | undefined {
+  if (!value) {
+    return undefined
+  }
+
+  const date = value instanceof Date ? value : new Date(value as string)
+
+  if (Number.isNaN(date.getTime())) {
+    return undefined
+  }
+
+  return date.toISOString()
+}
+
+function ensureFutureDate(value?: string): string {
+  if (value) {
+    const date = new Date(value)
+    if (!Number.isNaN(date.getTime())) {
+      return date.toISOString()
+    }
+  }
+
+  const fallbackDate = new Date()
+  fallbackDate.setHours(fallbackDate.getHours() + 36)
+  return fallbackDate.toISOString()
+}
+
+function fallbackImageFor(destination: string): string {
+  const keyword = destination ? encodeURIComponent(destination) : "travel"
+  return `https://source.unsplash.com/800x600/?${keyword},city,skyline`
+}
+
+function fallbackAirlineLogo(): string {
+  return "/placeholder.svg"
+}
+
+function deriveDiscount(originalPrice: number, currentPrice: number): number {
+  if (originalPrice <= 0 || currentPrice <= 0 || currentPrice >= originalPrice) {
+    return 0
+  }
+
+  return Math.max(Math.round(((originalPrice - currentPrice) / originalPrice) * 100), 0)
+}
+
+function normalizePartner(rawPartner: unknown): AffiliatePartnerKey {
+  const partnerKey = parseString(rawPartner).toLowerCase()
+
+  if (partnerKey && partnerKey in AFFILIATE_PARTNERS) {
+    return partnerKey as AffiliatePartnerKey
+  }
+
+  return "booking"
+}
+
+export function extractDealsFromPayload(payload: unknown): unknown[] {
+  if (!payload) {
+    return []
+  }
+
+  if (Array.isArray(payload)) {
+    return payload
+  }
+
+  if (typeof payload === "object") {
+    const record = payload as Record<string, unknown>
+
+    if (Array.isArray(record.items)) {
+      return record.items
+    }
+
+    if (Array.isArray(record.deals)) {
+      return record.deals
+    }
+
+    if (Array.isArray(record.data)) {
+      return record.data
+    }
+
+    if (Array.isArray(record.results)) {
+      return record.results
+    }
+  }
+
+  return []
+}
+
+export function normalizeDeal(rawDeal: unknown, index = 0): NormalizedDeal | null {
+  if (!rawDeal || typeof rawDeal !== "object") {
+    return null
+  }
+
+  const record = rawDeal as Record<string, unknown>
+
+  const destination = parseString(
+    record.destination ?? record.city_name ?? record.city ?? record.to ?? "Onbekende bestemming",
+  )
+  const country = parseString(record.country ?? record.country_name ?? "Nederland")
+  const airline = parseString(record.airline ?? record.airline_name ?? record.carrier ?? "Onbekende maatschappij")
+
+  const currentPrice = toNumber(record.current_price ?? record.price ?? record.currentPrice ?? 0)
+  const originalCandidate = toNumber(
+    record.original_price ?? record.originalPrice ?? record.previous_price ?? record.originalFare ?? 0,
+  )
+
+  const originalPrice = originalCandidate > currentPrice && originalCandidate > 0 ? originalCandidate : currentPrice
+  const discountRaw = toNumber(record.discount_percentage ?? record.discount ?? record.discountPercent ?? 0)
+  const discountPercentage = discountRaw > 0 ? discountRaw : deriveDiscount(originalPrice, currentPrice)
+
+  const seats = toNumber(
+    record.seats_remaining ?? record.seats_available ?? record.available_seats ?? record.seats ?? 0,
+    0,
+  )
+  const seatsRemaining = seats > 0 ? Math.round(seats) : 6
+
+  const dealExpiresAt = ensureFutureDate(
+    parseDateToIso(
+      record.deal_expires_at ?? record.expiration_date ?? record.deal_expiration ?? record.expires_at ?? record.expiresAt,
+    ),
+  )
+
+  const departureDate = parseDateToIso(record.departure_date ?? record.depart_date ?? record.depart_at ?? record.departure_at)
+  const returnDate = parseDateToIso(record.return_date ?? record.return_at ?? record.returnDate)
+
+  const imageUrl = parseString(
+    record.image_url ?? record.image ?? record.imageUrl ?? record.destination_image_url ?? fallbackImageFor(destination),
+  )
+
+  const airlineLogoUrl = parseString(
+    record.airline_logo ?? record.airline_logo_url ?? record.airlineLogo ?? fallbackAirlineLogo(),
+  )
+
+  const rating = toNumber(record.rating, 0)
+  const reviewCount = toNumber(record.review_count ?? record.reviews ?? record.reviewCount, 0)
+  const competitorPrice = toNumber(record.competitor_price ?? record.competitorPrice, 0)
+  const dailyBookings = toNumber(record.daily_bookings ?? record.bookings_today ?? record.booking_count, 0)
+
+  const partner = normalizePartner(record.partner_id ?? record.partner ?? record.partnerKey ?? record.affiliate_partner)
+
+  const link = parseString(record.link ?? record.url ?? record.booking_url ?? record.deep_link ?? "")
+
+  const idValue = record.id ?? record.uuid ?? record.external_id
+  const numericId = Number.parseInt(parseString(idValue), 10)
+  const id = Number.isFinite(numericId) ? numericId : index + 1
+  const externalId = Number.isFinite(numericId) ? undefined : parseString(idValue || `deal-${index + 1}`)
+
+  return {
+    id,
+    externalId,
+    origin: parseString(record.origin ?? record.from ?? record.origin_city ?? record.origin_airport ?? ""),
+    destination,
+    country,
+    currentPrice,
+    originalPrice,
+    discountPercentage,
+    airline,
+    airlineLogoUrl: airlineLogoUrl || fallbackAirlineLogo(),
+    imageUrl: imageUrl || fallbackImageFor(destination),
+    departureDate: departureDate,
+    returnDate: returnDate,
+    seatsRemaining,
+    dealExpiresAt,
+    rating: rating > 0 ? Number(rating.toFixed(1)) : undefined,
+    reviewCount: reviewCount > 0 ? Math.round(reviewCount) : undefined,
+    competitorPrice: competitorPrice > 0 ? competitorPrice : undefined,
+    dailyBookings: dailyBookings > 0 ? Math.round(dailyBookings) : undefined,
+    partner,
+    link: link || undefined,
+    isFeatured: Boolean(record.is_featured ?? record.featured ?? record.isFeatured),
+    isDealOfDay: Boolean(record.is_deal_of_day ?? record.deal_of_day ?? record.dealOfDay),
+  }
+}
+
+export function normalizeDealsFromPayload(payload: unknown): NormalizedDeal[] {
+  return extractDealsFromPayload(payload)
+    .map((deal, index) => normalizeDeal(deal, index))
+    .filter((deal): deal is NormalizedDeal => Boolean(deal))
+}
+
+const departureFallback = new Date()
+departureFallback.setDate(departureFallback.getDate() + 7)
+
+const returnFallback = new Date()
+returnFallback.setDate(returnFallback.getDate() + 14)
+
+const expiresFallback = new Date()
+expiresFallback.setHours(expiresFallback.getHours() + 24)
+
+export const FALLBACK_DEAL: NormalizedDeal = {
+  id: 1,
+  externalId: "fallback-1",
+  origin: "Amsterdam (AMS)",
+  destination: "Barcelona",
+  country: "Spanje",
+  currentPrice: 199,
+  originalPrice: 299,
+  discountPercentage: 33,
+  airline: "KLM",
+  airlineLogoUrl: "/klm-logo.png",
+  imageUrl: "/barcelona-sagrada-familia-park-guell.png",
+  departureDate: departureFallback.toISOString(),
+  returnDate: returnFallback.toISOString(),
+  seatsRemaining: 5,
+  dealExpiresAt: expiresFallback.toISOString(),
+  rating: 4.8,
+  reviewCount: 182,
+  competitorPrice: 249,
+  dailyBookings: 32,
+  partner: "booking",
+  link: "https://www.klm.com",
+  isFeatured: true,
+  isDealOfDay: true,
+}


### PR DESCRIPTION
## Summary
- add shared deal normalisation helpers with configurable defaults for the SpotMijnVlucht API
- proxy /api/deals to the external Cloud Run service with environment-based auth and fallback data
- refactor the homepage to consume the normalised deals, surface loading/error states, and keep a featured fallback
- document environment variables and local development steps

## Testing
- `npm run lint` *(blocked by the Next.js interactive ESLint bootstrap prompt)*

------
https://chatgpt.com/codex/tasks/task_b_68cbc33d46848330879d48bfa69f7cf5